### PR TITLE
Fix malformed tags in first NIP-134 example event

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,8 @@ Example event:
     "kind": 31034,
     "created_at": 1682327852,
     "tags": [
-        [
-            "u", "http://example.com",
-            "d", ""
-        ]
+        ["u", "http://example.com"],
+        ["d", ""]
     ],
     "sig": "exampleSignature"
 }


### PR DESCRIPTION
The first example event flattened the `u` and `d` tags into a single 4-element array:

```json
"tags": [["u", "http://example.com", "d", ""]]
```

A client following this example would publish an event with no `d` tag at all (`d` becomes the third element of the `u` tag), so the event would not be addressable as a parameterized replaceable event with `d=""`, and lookups per the Implementation section would miss it.

Fixed to two separate tags, matching the tag definitions above and the DNS-record-set example later in the spec:

```json
"tags": [["u", "http://example.com"], ["d", ""]]
```

Only occurrence — the rest of the repo checks clean.