### PR TITLE
Remove broken "main" field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "type": "module",
   "version": "0.1.0",
   "description": "Resolve Nostr identities to domain names via did:nostr",
-  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
`package.json` declares `"main": "index.js"`, but no `index.js` exists in the repo — the only entry point is the CLI at `bin/dnstr.js`. Importing the published `dnstr` package therefore fails with `ERR_MODULE_NOT_FOUND`.

Since this is a CLI-only package (it already declares `bin`), the fix is simply to drop the `main` field.